### PR TITLE
fix: separate auth0 from users

### DIFF
--- a/ENCRYPTION_SETUP.md
+++ b/ENCRYPTION_SETUP.md
@@ -75,7 +75,7 @@ $user = $userRepository->findByEmail('user@example.com');
 ### Creating a User
 ```php
 // Automatically encrypts email during creation
-$user = $userRepository->createUser($authId, $email, $username, $emailVerified);
+$user = $userRepository->createUser($email, $username, $emailVerified);
 ```
 
 ### Accessing Email Data

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ This section contains initial user stories for the early development phase. In t
 
 | Story Code    | User Roles     | Description      |
 | ------------- | ------------- | ------------- |
-| US2 | Guest | As a Guest, I want to sign up so I can become a Registered User. |
+| US2 ✅ | Guest | As a Guest, I want to sign up so I can become a Registered User. |
 | US3 | Registered User | As a Registered User, I want to sign in to obtain a session and access my authorized resources. |
 | US4 | Registered User | As a Registered User, I want to refresh my session without re-authenticating when eligible. |
-| US6 | Registered User | As a Registered User, I want to sign out so my current session cannot be reused. |
+| US6 ✅ | Registered User | As a Registered User, I want to sign out so my current session cannot be reused. |
 
 #### Organization & Membership
 

--- a/db/migrations/20250820084840_create_table_users.php
+++ b/db/migrations/20250820084840_create_table_users.php
@@ -20,10 +20,6 @@ final class CreateTableUsers extends AbstractMigration
     public function change(): void
     {
         $users = $this->table('users');
-        $users->addColumn('auth_id', 'string', [
-            'limit' => 255,
-            'null' => false,
-        ]);
         $users->addColumn('email_hash', 'string', [
             'limit' => 64,
             'null' => false,
@@ -60,15 +56,10 @@ final class CreateTableUsers extends AbstractMigration
             'null' => true,
             'default' => null,
         ]);
-        // Primary lookup index - auth_id is always unique
-        $users->addIndex(['auth_id'], [
-            'unique' => true,
-            'name' => 'idx_users_auth0_sub_unique',
-        ]);
         
         // Email hash lookup index - primary method for finding users by email
         $users->addIndex(['email_hash'], [
-            'unique' => false,
+            'unique' => true,
             'name' => 'idx_users_email_hash',
         ]);
         
@@ -77,6 +68,7 @@ final class CreateTableUsers extends AbstractMigration
             'unique' => false,
             'name' => 'idx_users_deleted_at',
         ]);
+        
         $users->create();
     }
 }

--- a/src/Http/Controllers/Auth0Controller.php
+++ b/src/Http/Controllers/Auth0Controller.php
@@ -78,7 +78,6 @@ final class Auth0Controller
             // fail safe method to ensure that the user is created in the database
             // even if the user is already present
             $this->userService->signUpVia3rdParty(
-                $user['sub'],
                 $user['email'],
                 $user['name'],
                 $user['email_verified'],

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -5,6 +5,7 @@ namespace App\User;
 
 /**
  * User Entity - Represents a user in the system
+ * Focused on business data only, auth concerns handled separately
  */
 final class User
 {
@@ -14,7 +15,6 @@ final class User
 
     public function __construct(
         private ?int $id,
-        private string $authId,
         private string $email, // Decrypted email for business logic use
         private string $emailHash, // Hash for database lookups
         private string $emailEncrypted, // Encrypted email for storage
@@ -33,11 +33,6 @@ final class User
     public function getId(): ?int
     {
         return $this->id;
-    }
-
-    public function getAuthId(): string
-    {
-        return $this->authId;
     }
 
     public function getEmail(): string

--- a/src/User/UserService.php
+++ b/src/User/UserService.php
@@ -10,29 +10,26 @@ final class UserService
     ) {}
 
     /**
-     * A service that allow sign up via 3rd party providers. Each
-     * caller must ensure that the authId is unique, regardless of
-     * the provider. If the authId is already present, the user data
-     * is considered to be already present and will be returned.
+     * A service that allows sign up via 3rd party providers.
+     * The email from the auth provider (Auth0, Twitter, etc.) is used as the unique identifier.
+     * If a user with the same email already exists, their profile data is updated and returned.
      *
-     * @param string $authId
      * @param string $email
      * @param string $username
      * @param bool $emailVerified
      * 
      * @return User
      */
-    public function signUpVia3rdParty(string $authId, string $email, string $username, bool $emailVerified): User
+    public function signUpVia3rdParty(string $email, string $username, bool $emailVerified): User
     {
-        $user = $this->userRepository->findByAuthId($authId);
+        $existingUser = $this->userRepository->findByEmail($email);
 
-        if ($user !== null) {
-            return $user;
+        if ($existingUser !== null) {
+            return $existingUser;
         }
 
-        $createdUser = $this->userRepository->createUser($authId, $email, $username, $emailVerified);
-
-        return $createdUser;
+        // Create new user
+        return $this->userRepository->createUser($email, $username, $emailVerified);
     }
     
     /**


### PR DESCRIPTION
I don't want to make auth provider tangled up with users, thus for now on, users and credentials data are now separate. Users, regardless of the auth provider, as long as have the same email in the users table, can access that users data